### PR TITLE
add support for dstPort 0 dynamic port selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,36 @@ npm i reverse-tunnel-ssh (--save)
 
 ```js
 
-// Tunnel your local port 8000 to tunneltest.com 
+// Tunnel your local port 8000 to tunneltest.com:8000
 
 //tunnel is a ssh2 clientConnection object
 var tunnel = require('reverse-tunnel-ssh');
 tunnel({
   host: 'tunneltest.com',
   username: 'root',
-  dstHost: '0.0.0.0', // bind to all interfaces
+  dstHost: '0.0.0.0', // bind to all IPv4 interfaces
   dstPort: 8000,
   //srcHost: '127.0.0.1', // default
   //srcPort: dstPort // default is the same as dstPort
 }, function(error, clientConnection) {
-  // 
+  //
+});
+
+// Tunnel your local port 8000 to a free port on tunneltest.com
+
+var conn = tunnel({
+  host: 'tunneltest.com',
+  username: 'somebody',
+  dstHost: '0.0.0.0', // bind to all IPv4 interfaces
+  dstPort: 0, // dynamically choose an open port on tunneltest.com
+  srcHost: 8000, // must be specified if dstPort=0
+}, function (error, clientConnection) {
+  //
+});
+conn.on('forward-in', function (port) {
+  console.log('Forwarding from tunneltest.com:' + port);
 });
 ```
-
 
 If you plan to expose a local port on a remote machine (external interface) you need to enable the "GatewayPorts" option in your 'sshd_config'
 
@@ -35,7 +49,3 @@ If you plan to expose a local port on a remote machine (external interface) you 
 Port 22
 GatewayPorts yes
 ```
-
-
-
-

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var Client = require('ssh2').Client;
 var Socket = require('net').Socket;
-var debug = require('debug');
+var debug = require('debug')('reverse-tunnel-ssh');
 
 var createConfig = require('./lib/config');
 
@@ -16,11 +16,12 @@ function createClient(rawConfig, callback) {
 
   conn.on('ready', function() {
     debug('ready');
-    conn.forwardIn(remoteHost, remotePort, function(err) {
+    conn.forwardIn(remoteHost, remotePort, function(err, port) {
       if (err) {
         errors.push(err);
         throw err;
       }
+      conn.emit('forward-in', port);
     });
   });
 
@@ -55,4 +56,3 @@ function createClient(rawConfig, callback) {
 }
 
 module.exports = createClient;
-

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,12 +18,15 @@ function createConfig(userConfig) {
   }
 
   // No local route, no remote route.. exit here
-  if (!config.dstPort || !config.dstHost || !config.host) {
+  if (config.dstPort == null || !config.dstHost || !config.host) {
     throw new Error('invalid configuration.');
   }
 
   // Use the same port number local
   if (config.srcPort === undefined) {
+    if (!config.dstPort) {
+      throw new Error('must specify srcPort when dstPort=0');
+    }
     config.srcPort = config.dstPort;
   }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "dependencies": {
     "debug": "2.2.0",
     "lodash.defaults": "4.0.1",
-    "ssh2": "0.5.0"
+    "ssh2": "0.5.2"
   }
 }


### PR DESCRIPTION
- modify config to allow dstPort to be 0 but not nully
- modify index.js to emit `forward-in` event with dynamic port
- update to ssh-0.5.2 which [works around an OpenSSH 5.x bug](https://github.com/mscdex/ssh2/commit/23f1e6791d27017d3ff09212694ae0043ad82109) related to this feature
- document in README
- fix `debug()` usage bug
