### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function createClient(rawConfig, callback) {
     conn.forwardIn(remoteHost, remotePort, function(err, port) {
       if (err) {
         errors.push(err);
-        throw err;
+        conn.emit('error', err);
       }
       conn.emit('forward-in', port);
     });


### PR DESCRIPTION
changed throw() in the callback to emit("error") , the exception in callback cannot be caught. 